### PR TITLE
fix: sync preview PDP with selected mock product

### DIFF
--- a/assets/preview.js
+++ b/assets/preview.js
@@ -1,550 +1,682 @@
-const previewProducts = [
-  {
-    id: 7902382751894,
-    handle: 'the-monsters-exciting-macaron-series-plush-pendant-blind-box',
-    url: 'https://toybeta.com/products/the-monsters-exciting-macaron-series-plush-pendant-blind-box',
-    title: 'Labubu V1 The Monsters Exciting Macaron Series Plush Pendant Blind Box',
-    vendor: 'POPMART',
-    type: 'Blind box',
-    tags: ['Best seller'],
-    price: 3999,
-    compare_at_price: 0,
-    featured_image: 'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/TheMonsters_5.jpg?v=1718961686',
-    images: [
-      'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/TheMonsters_5.jpg?v=1718961686',
-      'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/TheMonsters_3.jpg?v=1718961686',
-      'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/TheMonsters_8.jpg?v=1718961686',
-      'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/TheMonsters_9.jpg?v=1704967184'
-    ],
-    variants: [
-      { id: 44286667292822, title: '2 Boxes', price: 7499, available: true },
-      { id: 43018504470678, title: '1 Box', price: 3999, available: true },
-      { id: 43018505584790, title: 'Whole Set(6Boxes)', price: 22900, available: true },
-      { id: 44233867919510, title: 'Secret', price: 17900, available: false }
-    ],
-    badge: 'Best seller',
-    kicker: 'Blind box',
-    status: 'In stock now',
-    cartNote: 'Macaron blind box'
-  },
-  {
-    id: 8205366755478,
-    handle: 'pre-sale-the-monsters-labubu-have-a-seat-vinyl-plush-blind-box',
-    url: 'https://toybeta.com/products/pre-sale-the-monsters-labubu-have-a-seat-vinyl-plush-blind-box',
-    title: 'Labubu V2 THE MONSTERS- Have a Seat Vinyl Plush Blind Box',
-    vendor: 'POPMART',
-    type: 'Vinyl plush',
-    tags: ['Trending'],
-    price: 3999,
-    compare_at_price: 0,
-    featured_image: 'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/1_16352f24-639c-47be-95b3-53e549337093.webp?v=1757763787',
-    images: [
-      'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/1_16352f24-639c-47be-95b3-53e549337093.webp?v=1757763787',
-      'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/20240710_102728_027308____the-monsters-have-a-seat-vinyl-plush-blind-box-blind-boxes-pop-mart-us-scene_1_____1200x1200_074867a9-e593-4f61-b28a-76f4d684940d.jpg?v=1757763787',
-      'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/4_ce471e75-f1e4-4648-b049-ee532fae050c.webp?v=1757763787',
-      'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/2_c4478143-663e-40b8-8acf-cb1793ccf539.webp?v=1757763787'
-    ],
-    variants: [
-      { id: 44227871768726, title: '2 Boxes', price: 6999, available: true },
-      { id: 43863642341526, title: '1 Box', price: 3999, available: true },
-      { id: 43863685595286, title: 'Whole Set(6Boxes)', price: 22900, available: true },
-      { id: 44226468249750, title: 'Secret', price: 12900, available: false }
-    ],
-    badge: 'Trending',
-    kicker: 'Vinyl plush',
-    status: 'Popular preorder',
-    cartNote: 'Have a Seat blind box'
-  },
-  {
-    id: 8181201961110,
-    handle: 'nanci-museum-of-fantasy-series-blind-box',
-    url: 'https://toybeta.com/products/nanci-museum-of-fantasy-series-blind-box',
-    title: 'Nanci Museum Of Fantasy Series Blind Box Figures【Rolife】',
-    vendor: 'ROLIFE',
-    type: 'Mini figure',
-    tags: ['New arrival'],
-    price: 1386,
-    compare_at_price: 0,
-    featured_image: 'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/NANCIMUSEUM_11.jpg?v=1756116098',
-    images: [
-      'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/NANCIMUSEUM_11.jpg?v=1756116098',
-      'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/NANCI_MUSEUM_16.jpg?v=1756116076',
-      'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/NANCIMUSEUM_1.jpg?v=1756116116',
-      'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/NANCIMUSEUM_2.jpg?v=1756116076'
-    ],
-    variants: [
-      { id: 43795518259350, title: '1 Box', price: 1386, available: true },
-      { id: 43795518292118, title: 'Whole Set (12 boxes)', price: 15800, available: true },
-      { id: 44427199676566, title: 'Secret', price: 6900, available: false }
-    ],
-    badge: 'New arrival',
-    kicker: 'Mini figure',
-    status: 'Ships in 48 hrs',
-    cartNote: 'Rolife blind box'
-  },
-  {
-    id: 8188523806870,
-    handle: 'sale-skullpanda-the-sound-series-blind-box-figures',
-    url: 'https://toybeta.com/products/sale-skullpanda-the-sound-series-blind-box-figures',
-    title: 'SKULLPANDA The Sound Series Blind Box Figures',
-    vendor: 'POPMART',
-    type: 'Blind box',
-    tags: ['Collector pick'],
-    price: 1999,
-    compare_at_price: 0,
-    featured_image: 'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/20240619_183053_776678____skullpanda-the-sound-series-figures-blind-boxes-pop-mart-us-details-8_____1200x1563_0086dd02-0cad-435e-9375-be755d9be308.webp?v=1763552890',
-    images: [
-      'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/20240619_183053_776678____skullpanda-the-sound-series-figures-blind-boxes-pop-mart-us-details-8_____1200x1563_0086dd02-0cad-435e-9375-be755d9be308.webp?v=1763552890',
-      'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/20240619_183041_027147____skullpanda-the-sound-series-figures-blind-boxes-pop-mart-us-scene_1_____1200x1200_36241ba9-e741-4b17-96bd-17ba9a0e9900.jpg?v=1763552890',
-      'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/20240619_183053_098207____skullpanda-the-sound-series-figures-blind-boxes-pop-mart-us-details-7_____1200x1568_aa6ae10a-83d1-4db1-a4ce-1167b2ca5794.webp?v=1763552890',
-      'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/20240619_183053_744630____skullpanda-the-sound-series-figures-blind-boxes-pop-mart-us-details-11_____1200x1566_9cd4e6fe-5212-4b68-98d1-927b8e90e60b.webp?v=1763552890'
-    ],
-    variants: [
-      { id: 43814872809622, title: '1 Box', price: 1999, available: true },
-      { id: 43814872842390, title: 'Whole Set (12Boxes)', price: 22500, available: true },
-      { id: 43986505629846, title: 'Anger+Trust+Ecstasy+Joy', price: 9900, available: false },
-      { id: 45782357934230, title: 'sample (Vigilance)', price: 1999, available: false }
-    ],
-    badge: 'Collector pick',
-    kicker: 'Blind box',
-    status: 'Low stock',
-    cartNote: 'Sound series'
-  },
-  {
-    id: 8200076329110,
-    handle: 'liitas-dream-series-blind-box',
-    url: 'https://toybeta.com/products/liitas-dream-series-blind-box',
-    title: '【TNTSpace】Liita\'s Dream Series Blind Box',
-    vendor: 'TNTSPACE',
-    type: 'Blind box',
-    tags: ['Giftable'],
-    price: 1650,
-    compare_at_price: 0,
-    featured_image: 'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/liitadream_6.jpg?v=1764742234',
-    images: [
-      'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/liitadream_6.jpg?v=1764742234',
-      'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/liitadream_12.jpg?v=1764742234',
-      'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/liitadream_5.jpg?v=1764742234',
-      'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/liitadream_10.jpg?v=1764742234'
-    ],
-    variants: [
-      { id: 43844994728086, title: '1 Box', price: 1750, available: true },
-      { id: 43844994760854, title: 'Whole Set (9 boxes)', price: 15750, available: true },
-      { id: 43847648936086, title: 'Special-Hanging Card', price: 3900, available: false },
-      { id: 43847621771414, title: 'Card Binder', price: 3500, available: false }
-    ],
-    badge: 'Giftable',
-    kicker: 'Blind box',
-    status: 'Bundle favorite',
-    cartNote: 'Dream series'
-  },
-  {
-    id: 'collector-sleeve',
-    handle: 'collector-sleeve',
-    title: 'Collector Sleeve',
-    vendor: 'Toybeta Lab',
-    type: 'Add-on',
-    tags: ['Upsell'],
-    price: 1200,
-    compare_at_price: 0,
-    featured_image: '',
-    images: [],
-    variants: [{ id: 'collector-sleeve-default', title: 'Default Title', price: 1200, available: true }],
-    badge: 'Upsell',
-    kicker: 'Add-on',
-    status: 'Ships with order',
-    bg: ['#fff0d6', '#ffe3ef'],
-    cartNote: 'Archive-safe protector'
-  }
-];
-
-const previewAddOns = [
-  {
-    id: 'collector-sleeve',
-    title: 'Collector Sleeve',
-    price: 1200,
-    copy: 'Archive-safe protector that ships with the main order and adds an easy AOV lift.',
-    sourceNote: 'Still a manual add-on card in preview mode, but now merchandised alongside real ToyBeta product data.',
-    cta: 'Add sleeve'
-  },
-  {
-    id: 'vip-gift-wrap',
-    title: 'VIP Gift Wrap',
-    price: 800,
-    copy: 'Premium wrap, insert card, and launch-note packaging for gifting or creator sends.',
-    sourceNote: 'Second manual card stays lightweight while the main catalog uses live public product names and images.',
-    cta: 'Preview slot'
-  }
-];
-
-const storefront = window.ToybetaStorefront || { config: { mode: 'local_preview' }, cart: null };
-const storefrontConfig = window.TOYBETA_STOREFRONT_CONFIG || {};
-const cartApi = storefront.cart;
-const featuredBaseProduct = previewProducts.find((product) => product.handle === 'pre-sale-the-monsters-labubu-have-a-seat-vinyl-plush-blind-box') || previewProducts[0];
-
-const featuredProduct = {
-  id: featuredBaseProduct.id,
-  handle: featuredBaseProduct.handle,
-  title: featuredBaseProduct.title,
-  vendor: featuredBaseProduct.vendor,
-  variants: featuredBaseProduct.variants.map((variant, index) => ({
-    id: String(variant.id),
-    shopifyVariantId: variant.id,
-    title: variant.title,
-    price: variant.price,
-    stock: variant.available ? (index === 0 ? 'Fast-moving preorder' : index === 1 ? 'Ready to ship' : 'Factory batch reserved') : 'Currently sold out',
-    bundle: variant.available ? (variant.title.toLowerCase().includes('whole set') ? 'Best value for collectors' : 'Great entry-point option') : 'Use as merchandising proof only',
-    note: variant.title,
-    available: variant.available
-  })),
-  media: featuredBaseProduct.images.map((src, index) => ({
-    id: `media-${index + 1}`,
-    label: index === 0 ? 'Hero image' : index === 1 ? 'Lifestyle scene' : index === 2 ? 'Detail close-up' : 'Packaging view',
-    src
-  }))
-};
-
-let selectedVariantId = featuredProduct.variants[0].id;
-let selectedMediaId = featuredProduct.media[0].id;
-let previewCart = null;
-
-const cartThresholds = {
-  freeShipping: Number(storefrontConfig.cart?.freeShippingThreshold || 7500) / 100,
-  freeGift: Number(storefrontConfig.cart?.freeGiftThreshold || 9000) / 100
-};
-
-function formatMoney(value) {
-  return `$${value.toFixed(2)}`;
-}
-
-function formatCents(value) {
-  return formatMoney((Number(value) || 0) / 100);
-}
-
-function getProductPrice(product) {
-  return Number(product?.price || 0) / 100;
-}
-
-function getProductCompareAt(product) {
-  return Number(product?.compare_at_price || 0) / 100;
-}
-
-function createProductArt(title, [start, end], subtitle = '') {
-  const label = encodeURIComponent(title.toUpperCase());
-  const sub = encodeURIComponent(subtitle.toUpperCase());
-  return `data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 640 640'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0' y1='0' x2='1' y2='1'%3E%3Cstop stop-color='${encodeURIComponent(start)}'/%3E%3Cstop offset='1' stop-color='${encodeURIComponent(end)}'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect width='640' height='640' rx='40' fill='url(%23g)'/%3E%3Ccircle cx='194' cy='190' r='92' fill='%23ffffff' fill-opacity='.52'/%3E%3Ccircle cx='462' cy='430' r='126' fill='%23ffffff' fill-opacity='.28'/%3E%3Crect x='196' y='176' width='248' height='280' rx='110' fill='%23ffffff' fill-opacity='.92'/%3E%3Crect x='162' y='424' width='316' height='72' rx='36' fill='%231f2544' fill-opacity='.85'/%3E%3Ctext x='320' y='548' text-anchor='middle' font-family='Arial, sans-serif' font-size='30' font-weight='700' fill='%231f2544'%3E${label}%3C/text%3E%3Ctext x='320' y='585' text-anchor='middle' font-family='Arial, sans-serif' font-size='18' font-weight='700' fill='%236b7087'%3E${sub}%3C/text%3E%3C/svg%3E`;
-}
-
-function getProductImage(product, fallbackSubtitle = '') {
-  if (product?.featured_image) return product.featured_image;
-  return createProductArt(product?.title || 'Toybeta Preview', product?.bg || ['#ffd8e2', '#efe7ff'], fallbackSubtitle);
-}
-
-function getProduct(productId) {
-  return previewProducts.find((product) => String(product.id) === String(productId) || product.handle === productId);
-}
-
-function getSelectedVariant() {
-  return featuredProduct.variants.find((variant) => variant.id === selectedVariantId) || featuredProduct.variants[0];
-}
-
-function getSelectedMedia() {
-  return featuredProduct.media.find((media) => media.id === selectedMediaId) || featuredProduct.media[0];
-}
-
-function renderPreviewProducts() {
-  const grid = document.getElementById('preview-product-grid');
-  if (!grid) return;
-
-  grid.innerHTML = previewProducts
-    .filter((product) => product.id !== 'collector-sleeve')
-    .map((product) => `
-      <article class="card">
-        <a class="card-link" href="#product-preview" aria-label="${product.title}">
-          <div class="card-media">
-            <img src="${getProductImage(product, product.kicker)}" alt="${product.title}">
-          </div>
-          <div class="card-body">
-            <div class="card-meta">
-              <div class="badge">${product.badge}</div>
-              <div class="card-kicker">${product.kicker}</div>
-            </div>
-            <h3>${product.title}</h3>
-            <div class="text-muted">${product.vendor}</div>
-            <div class="card-footer">
-              <div>
-                <span class="price">${formatCents(product.price)}</span>
-                ${product.compare_at_price ? `<span class="compare-at">${formatCents(product.compare_at_price)}</span>` : ''}
-              </div>
-              <span class="card-cta">Quick look →</span>
-            </div>
-            <div class="card-availability">${product.status}</div>
-          </div>
-        </a>
-        <div class="card-actions">
-          <button class="btn btn-secondary" type="button" data-preview-view="${product.id}">Preview details</button>
-          <button class="btn btn-primary" type="button" data-preview-add="${product.id}">Add to cart</button>
-        </div>
-      </article>
-    `).join('');
-}
-
-function syncSecondaryGrid() {
-  const secondaryGrid = document.getElementById('preview-product-grid-secondary');
-  const primaryGrid = document.getElementById('preview-product-grid');
-  if (secondaryGrid && primaryGrid) secondaryGrid.innerHTML = primaryGrid.innerHTML;
-}
-
-function renderAddOnPreview() {
-  const addOnStack = document.getElementById('preview-addon-stack');
-  if (!addOnStack) return;
-
-  addOnStack.innerHTML = previewAddOns.map((item) => {
-    const product = getProduct(item.id) || { title: item.title, bg: ['#fff0d6', '#ffe3ef'] };
-    return `
-      <article class="drawer-item">
-        <div class="drawer-thumb"><img src="${getProductImage(product, 'Add-on')}" alt="${item.title}"></div>
-        <div>
-          <div class="drawer-item-row"><strong>${item.title}</strong><span>${formatCents(item.price)}</span></div>
-          <div class="text-muted">${item.copy}</div>
-          <div class="quick-add-copy">${item.sourceNote}</div>
-          <button class="btn btn-secondary" type="button" data-preview-addon="${item.id}">${item.cta}</button>
-        </div>
-      </article>
-    `;
-  }).join('');
-}
-
-function renderProductExperience() {
-  const select = document.getElementById('variant-demo');
-  const chipRow = document.getElementById('variant-chip-row');
-  const thumbs = document.getElementById('product-thumbs');
-  const mainImage = document.getElementById('product-main-image');
-  const floatingNote = document.getElementById('gallery-floating-note');
-  const stockChip = document.getElementById('variant-stock-chip');
-  const priceChip = document.getElementById('variant-price-chip');
-  const bundleChip = document.getElementById('variant-bundle-chip');
-  const submit = document.getElementById('product-submit-button');
-  if (!select || !chipRow || !thumbs || !mainImage) return;
-
-  select.innerHTML = featuredProduct.variants.map((variant) => `<option value="${variant.id}">${variant.title}</option>`).join('');
-  select.value = selectedVariantId;
-
-  chipRow.innerHTML = featuredProduct.variants.map((variant) => `
-    <button class="variant-chip ${variant.id === selectedVariantId ? 'is-active' : ''}" type="button" data-variant-id="${variant.id}">${variant.title}</button>
-  `).join('');
-
-  thumbs.innerHTML = featuredProduct.media.map((media) => `
-    <button class="product-thumb-button ${media.id === selectedMediaId ? 'is-active' : ''}" type="button" data-media-id="${media.id}" aria-label="${media.label}">
-      <img src="${media.src}" alt="${media.label}">
-    </button>
-  `).join('');
-
-  const variant = getSelectedVariant();
-  const media = getSelectedMedia();
-  mainImage.src = media.src;
-  mainImage.alt = `${featuredProduct.title} ${media.label}`;
-  floatingNote.textContent = media.label;
-  stockChip.textContent = variant.stock;
-  priceChip.textContent = formatCents(variant.price);
-  bundleChip.textContent = variant.bundle;
-  if (submit) submit.textContent = variant.available ? `Add ${variant.title} to cart` : `${variant.title} sold out`;
-  if (submit) submit.disabled = !variant.available;
-}
-
-function getCartSubtotal(cart) {
-  return (cart?.total_price || 0) / 100;
-}
-
-function renderCart(cart) {
-  previewCart = cart;
-  const itemsWrap = document.getElementById('cart-drawer-items');
-  const miniPreview = document.getElementById('mini-cart-preview');
-  const total = document.getElementById('cart-total');
-  const count = document.getElementById('cart-browse-count');
-  const progress = document.getElementById('cart-progress-copy');
-  const progressLabel = document.getElementById('cart-progress-label');
-  const progressFill = document.getElementById('cart-progress-fill');
-  const heading = document.getElementById('cart-drawer-heading');
-  const thresholdCopy = document.querySelector('[data-cart-threshold-copy]');
-  if (!itemsWrap || !miniPreview || !total || !count) return;
-
-  if (thresholdCopy) {
-    thresholdCopy.textContent = `Free shipping at ${formatMoney(cartThresholds.freeShipping)}, free gift at ${formatMoney(cartThresholds.freeGift)}`;
-  }
-
-  const subtotal = getCartSubtotal(cart);
-  const countValue = cart.item_count || 0;
-  const freeShippingGap = Math.max(0, cartThresholds.freeShipping - subtotal);
-  const freeGiftGap = Math.max(0, cartThresholds.freeGift - subtotal);
-  const progressPercent = Math.min(100, (subtotal / cartThresholds.freeGift) * 100);
-
-  count.textContent = `${countValue} item${countValue === 1 ? '' : 's'}`;
-  total.textContent = formatMoney(subtotal);
-  if (progressLabel) {
-    progressLabel.textContent = freeGiftGap > 0
-      ? `${Math.round(progressPercent)}% to your free gift`
-      : 'Free gift unlocked';
-  }
-  if (progressFill) progressFill.style.width = `${progressPercent}%`;
-  if (progress) {
-    if (freeShippingGap > 0) {
-      progress.textContent = `Add ${formatMoney(freeShippingGap)} more for free shipping, then ${formatMoney(freeGiftGap)} more unlocks the collector gift.`;
-    } else if (freeGiftGap > 0) {
-      progress.textContent = `Free shipping unlocked. Add ${formatMoney(freeGiftGap)} more to score the collector gift.`;
-    } else {
-      progress.textContent = 'Free shipping and the collector gift are both unlocked. This is the moment to push checkout.';
+(() => {
+  const previewProducts = [
+    {
+      id: 7902382751894,
+      handle: 'the-monsters-exciting-macaron-series-plush-pendant-blind-box',
+      url: 'https://toybeta.com/products/the-monsters-exciting-macaron-series-plush-pendant-blind-box',
+      title: 'Labubu V1 The Monsters Exciting Macaron Series Plush Pendant Blind Box',
+      vendor: 'POPMART',
+      type: 'Blind box',
+      tags: ['Best seller'],
+      price: 3999,
+      compare_at_price: 0,
+      featured_image: 'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/TheMonsters_5.jpg?v=1718961686',
+      images: [
+        'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/TheMonsters_5.jpg?v=1718961686',
+        'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/TheMonsters_3.jpg?v=1718961686',
+        'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/TheMonsters_8.jpg?v=1718961686',
+        'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/TheMonsters_9.jpg?v=1704967184'
+      ],
+      variants: [
+        { id: 44286667292822, title: '2 Boxes', price: 7499, available: true },
+        { id: 43018504470678, title: '1 Box', price: 3999, available: true },
+        { id: 43018505584790, title: 'Whole Set(6Boxes)', price: 22900, available: true },
+        { id: 44233867919510, title: 'Secret', price: 17900, available: false }
+      ],
+      badge: 'Best seller',
+      kicker: 'Blind box',
+      status: 'In stock now',
+      description: 'A crowd-favorite Labubu drop with plush pendant styling, easy entry pricing, and whole-set upsell potential built right into the variant ladder.',
+      highlights: ['Best seller', 'Fast ship', 'Giftable'],
+      cartNote: 'Macaron blind box'
+    },
+    {
+      id: 8205366755478,
+      handle: 'pre-sale-the-monsters-labubu-have-a-seat-vinyl-plush-blind-box',
+      url: 'https://toybeta.com/products/pre-sale-the-monsters-labubu-have-a-seat-vinyl-plush-blind-box',
+      title: 'Labubu V2 THE MONSTERS- Have a Seat Vinyl Plush Blind Box',
+      vendor: 'POPMART',
+      type: 'Vinyl plush',
+      tags: ['Trending'],
+      price: 3999,
+      compare_at_price: 0,
+      featured_image: 'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/1_16352f24-639c-47be-95b3-53e549337093.webp?v=1757763787',
+      images: [
+        'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/1_16352f24-639c-47be-95b3-53e549337093.webp?v=1757763787',
+        'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/20240710_102728_027308____the-monsters-have-a-seat-vinyl-plush-blind-box-blind-boxes-pop-mart-us-scene_1_____1200x1200_074867a9-e593-4f61-b28a-76f4d684940d.jpg?v=1757763787',
+        'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/4_ce471e75-f1e4-4648-b049-ee532fae050c.webp?v=1757763787',
+        'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/2_c4478143-663e-40b8-8acf-cb1793ccf539.webp?v=1757763787'
+      ],
+      variants: [
+        { id: 44227871768726, title: '2 Boxes', price: 6999, available: true },
+        { id: 43863642341526, title: '1 Box', price: 3999, available: true },
+        { id: 43863685595286, title: 'Whole Set(6Boxes)', price: 22900, available: true },
+        { id: 44226468249750, title: 'Secret', price: 12900, available: false }
+      ],
+      badge: 'Trending',
+      kicker: 'Vinyl plush',
+      status: 'Popular preorder',
+      description: 'Soft-touch vinyl plush styling with strong preorder appeal and enough variant spread to show how the PDP should shift for each shopper path.',
+      highlights: ['Popular preorder', 'Tracked shipping', 'Collector favorite'],
+      cartNote: 'Have a Seat blind box'
+    },
+    {
+      id: 8181201961110,
+      handle: 'nanci-museum-of-fantasy-series-blind-box',
+      url: 'https://toybeta.com/products/nanci-museum-of-fantasy-series-blind-box',
+      title: 'Nanci Museum Of Fantasy Series Blind Box Figures【Rolife】',
+      vendor: 'ROLIFE',
+      type: 'Mini figure',
+      tags: ['New arrival'],
+      price: 1386,
+      compare_at_price: 0,
+      featured_image: 'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/NANCIMUSEUM_11.jpg?v=1756116098',
+      images: [
+        'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/NANCIMUSEUM_11.jpg?v=1756116098',
+        'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/NANCI_MUSEUM_16.jpg?v=1756116076',
+        'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/NANCIMUSEUM_1.jpg?v=1756116116',
+        'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/NANCIMUSEUM_2.jpg?v=1756116076'
+      ],
+      variants: [
+        { id: 43795518259350, title: '1 Box', price: 1386, available: true },
+        { id: 43795518292118, title: 'Whole Set (12 boxes)', price: 15800, available: true },
+        { id: 44427199676566, title: 'Secret', price: 6900, available: false }
+      ],
+      badge: 'New arrival',
+      kicker: 'Mini figure',
+      status: 'Ships in 48 hrs',
+      description: 'Rolife fantasy figures give the preview a lighter price point while still showing a believable image gallery and whole-set purchase path.',
+      highlights: ['New arrival', 'Ships in 48 hrs', 'Display-ready'],
+      cartNote: 'Rolife blind box'
+    },
+    {
+      id: 8188523806870,
+      handle: 'sale-skullpanda-the-sound-series-blind-box-figures',
+      url: 'https://toybeta.com/products/sale-skullpanda-the-sound-series-blind-box-figures',
+      title: 'SKULLPANDA The Sound Series Blind Box Figures',
+      vendor: 'POPMART',
+      type: 'Blind box',
+      tags: ['Collector pick'],
+      price: 1999,
+      compare_at_price: 0,
+      featured_image: 'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/20240619_183053_776678____skullpanda-the-sound-series-figures-blind-boxes-pop-mart-us-details-8_____1200x1563_0086dd02-0cad-435e-9375-be755d9be308.webp?v=1763552890',
+      images: [
+        'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/20240619_183053_776678____skullpanda-the-sound-series-figures-blind-boxes-pop-mart-us-details-8_____1200x1563_0086dd02-0cad-435e-9375-be755d9be308.webp?v=1763552890',
+        'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/20240619_183041_027147____skullpanda-the-sound-series-figures-blind-boxes-pop-mart-us-scene_1_____1200x1200_36241ba9-e741-4b17-96bd-17ba9a0e9900.jpg?v=1763552890',
+        'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/20240619_183053_098207____skullpanda-the-sound-series-figures-blind-boxes-pop-mart-us-details-7_____1200x1568_aa6ae10a-83d1-4db1-a4ce-1167b2ca5794.webp?v=1763552890',
+        'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/20240619_183053_744630____skullpanda-the-sound-series-figures-blind-boxes-pop-mart-us-details-11_____1200x1566_9cd4e6fe-5212-4b68-98d1-927b8e90e60b.webp?v=1763552890'
+      ],
+      variants: [
+        { id: 43814872809622, title: '1 Box', price: 1999, available: true },
+        { id: 43814872842390, title: 'Whole Set (12Boxes)', price: 22500, available: true },
+        { id: 43986505629846, title: 'Anger+Trust+Ecstasy+Joy', price: 9900, available: false },
+        { id: 45782357934230, title: 'sample (Vigilance)', price: 1999, available: false }
+      ],
+      badge: 'Collector pick',
+      kicker: 'Blind box',
+      status: 'Low stock',
+      description: 'A stronger collector-focused SKU with low-stock energy, making it useful for testing urgency copy and sold-out variant behavior in the same preview flow.',
+      highlights: ['Collector pick', 'Low stock', 'Bundle-friendly'],
+      cartNote: 'Sound series'
+    },
+    {
+      id: 8200076329110,
+      handle: 'liitas-dream-series-blind-box',
+      url: 'https://toybeta.com/products/liitas-dream-series-blind-box',
+      title: '【TNTSpace】Liita\'s Dream Series Blind Box',
+      vendor: 'TNTSPACE',
+      type: 'Blind box',
+      tags: ['Giftable'],
+      price: 1650,
+      compare_at_price: 0,
+      featured_image: 'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/liitadream_6.jpg?v=1764742234',
+      images: [
+        'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/liitadream_6.jpg?v=1764742234',
+        'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/liitadream_12.jpg?v=1764742234',
+        'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/liitadream_5.jpg?v=1764742234',
+        'https://cdn.shopify.com/s/files/1/0485/7823/2470/files/liitadream_10.jpg?v=1764742234'
+      ],
+      variants: [
+        { id: 43844994728086, title: '1 Box', price: 1750, available: true },
+        { id: 43844994760854, title: 'Whole Set (9 boxes)', price: 15750, available: true },
+        { id: 43847648936086, title: 'Special-Hanging Card', price: 3900, available: false },
+        { id: 43847621771414, title: 'Card Binder', price: 3500, available: false }
+      ],
+      badge: 'Giftable',
+      kicker: 'Blind box',
+      status: 'Bundle favorite',
+      description: 'A softer gift-oriented product card that still benefits from dynamic PDP switching, especially when merchants want to compare tone across the lineup.',
+      highlights: ['Giftable', 'Bundle favorite', 'Easy add-on fit'],
+      cartNote: 'Dream series'
+    },
+    {
+      id: 'collector-sleeve',
+      handle: 'collector-sleeve',
+      title: 'Collector Sleeve',
+      vendor: 'Toybeta Lab',
+      type: 'Add-on',
+      tags: ['Upsell'],
+      price: 1200,
+      compare_at_price: 0,
+      featured_image: '',
+      images: [],
+      variants: [{ id: 'collector-sleeve-default', title: 'Default Title', price: 1200, available: true }],
+      badge: 'Upsell',
+      kicker: 'Add-on',
+      status: 'Ships with order',
+      bg: ['#fff0d6', '#ffe3ef'],
+      cartNote: 'Archive-safe protector'
     }
-  }
-  if (heading) heading.textContent = countValue ? `You have ${countValue} collector pick${countValue === 1 ? '' : 's'} ready` : 'Your drop is almost locked in';
+  ];
 
-  const markup = (cart.items || []).map((item) => {
-    const product = getProduct(item.productId) || { title: item.product_title || featuredProduct.title, price: (item.unitPrice || getSelectedVariant().price), bg: item.bg || ['#ffd7df', '#d6d8ff'], cartNote: item.variantTitle };
-    const lineTotal = (item.final_line_price || ((item.unitPrice || product.price) * item.quantity)) / 100;
-    const image = item.image || getProductImage(product, item.variantTitle || product.cartNote || 'Collector pick');
-    return `
-      <article class="drawer-item">
-        <div class="drawer-thumb"><img src="${image}" alt="${product.title}"></div>
-        <div>
-          <div class="drawer-item-row"><strong>${product.title}</strong><span>${formatMoney(lineTotal)}</span></div>
-          <div class="text-muted">${item.variantTitle || product.cartNote || 'Collector pick'}</div>
-          <div class="drawer-item-meta">
-            <div class="qty-stepper">
-              <button type="button" data-cart-qty="decrease" data-cart-key="${item.key}">−</button>
-              <span>${item.quantity}</span>
-              <button type="button" data-cart-qty="increase" data-cart-key="${item.key}">+</button>
-            </div>
-            <button class="btn btn-secondary" type="button" data-cart-remove="${item.key}">Remove</button>
-          </div>
-        </div>
-      </article>
-    `;
-  }).join('');
+  const previewAddOns = [
+    {
+      id: 'collector-sleeve',
+      title: 'Collector Sleeve',
+      price: 1200,
+      copy: 'Archive-safe protector that ships with the main order and adds an easy AOV lift.',
+      sourceNote: 'Still a manual add-on card in preview mode, but now merchandised alongside real ToyBeta product data.',
+      cta: 'Add sleeve'
+    },
+    {
+      id: 'vip-gift-wrap',
+      title: 'VIP Gift Wrap',
+      price: 800,
+      copy: 'Premium wrap, insert card, and launch-note packaging for gifting or creator sends.',
+      sourceNote: 'Second manual card stays lightweight while the main catalog uses live public product names and images.',
+      cta: 'Preview slot'
+    }
+  ];
 
-  const emptyMarkup = '<div class="drawer-note text-muted"><p>Your cart is empty in preview mode. Add a hero SKU or an upsell to show the drawer flow.</p></div>';
-  itemsWrap.innerHTML = markup || emptyMarkup;
-  miniPreview.innerHTML = markup ? (cart.items || []).slice(0, 1).map((item) => {
-    const product = getProduct(item.productId) || { title: item.product_title || featuredProduct.title, price: item.unitPrice || getSelectedVariant().price, bg: ['#ffd7df', '#d6d8ff'], cartNote: item.variantTitle };
-    const image = item.image || getProductImage(product, item.variantTitle || '');
-    return `<div class="drawer-item"><div class="drawer-thumb"><img src="${image}" alt="${product.title}"></div><div><div class="drawer-item-row"><strong>${product.title}</strong><span>${formatMoney((item.final_line_price || ((item.unitPrice || product.price) * item.quantity)) / 100)}</span></div><div class="text-muted">Qty ${item.quantity} • ${item.variantTitle || product.cartNote || 'Collector pick'}</div></div></div>`;
-  }).join('') : '<div class="text-muted"><p>No items yet. This panel updates with the drawer state.</p></div>';
-}
+  const previewStorefront = window.ToybetaStorefront || { config: { mode: 'local_preview' }, cart: null };
+  const previewStorefrontConfig = window.TOYBETA_STOREFRONT_CONFIG || {};
+  const previewCartApi = previewStorefront.cart;
+  const feedbackNode = document.getElementById('preview-cart-feedback');
 
-function addToCart(productId, quantity = 1, variantTitle = '', overrides = {}) {
-  const product = getProduct(productId);
-  const image = overrides.image || product?.featured_image || createProductArt(overrides.title || product?.title || featuredProduct.title, overrides.bg || product?.bg || ['#ffd7df', '#d6d8ff'], variantTitle || overrides.subtitle || '');
-  return cartApi.addItem({
-    id: productId,
-    productId,
-    product_title: overrides.title || product?.title || featuredProduct.title,
-    title: overrides.title || product?.title || featuredProduct.title,
-    quantity,
-    variantTitle,
-    unitPrice: Math.round(Number(overrides.unitPrice ?? product?.price ?? 0)),
-    image
-  });
-}
-
-function updateCartItem(cartKey, delta) {
-  const existing = (previewCart?.items || []).find((item) => item.key === cartKey);
-  if (!existing) return Promise.resolve(previewCart);
-  return cartApi.updateItem(cartKey, existing.quantity + delta);
-}
-
-function removeCartItem(cartKey) {
-  return cartApi.removeItem(cartKey);
-}
-
-document.addEventListener('click', (event) => {
-  const viewButton = event.target.closest('[data-preview-view]');
-  if (viewButton) {
-    document.getElementById('product-preview')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    return;
+  function toFeaturedProduct(product) {
+    return {
+      id: product.id,
+      handle: product.handle,
+      title: product.title,
+      vendor: product.vendor,
+      badge: product.badge,
+      kicker: product.kicker,
+      status: product.status,
+      description: product.description || 'A polished product template needs both story and reassurance. This layout gives the price, status, core benefits, and next-step cart behavior a tighter hierarchy.',
+      compareAtPrice: product.compare_at_price,
+      highlights: Array.isArray(product.highlights) && product.highlights.length ? product.highlights : ['Collector-grade packaging', 'Tracked shipping', 'Gift note ready'],
+      variants: product.variants.map((variant, index) => ({
+        id: String(variant.id),
+        shopifyVariantId: variant.id,
+        title: variant.title,
+        price: variant.price,
+        stock: variant.available ? (index === 0 ? product.status : index === 1 ? 'Ready to ship' : 'Factory batch reserved') : 'Currently sold out',
+        bundle: variant.available ? (variant.title.toLowerCase().includes('whole set') ? 'Best value for collectors' : 'Great entry-point option') : 'Use as merchandising proof only',
+        note: variant.title,
+        available: variant.available
+      })),
+      media: (product.images.length ? product.images : [getProductImage(product, product.kicker)]).map((src, index) => ({
+        id: `media-${index + 1}`,
+        label: index === 0 ? 'Hero image' : index === 1 ? 'Lifestyle scene' : index === 2 ? 'Detail close-up' : 'Packaging view',
+        src
+      }))
+    };
   }
 
-  const addButton = event.target.closest('[data-preview-add]');
-  if (addButton) {
-    const productId = addButton.dataset.previewAdd;
+  const defaultFeaturedBaseProduct = previewProducts.find((product) => product.handle === 'pre-sale-the-monsters-labubu-have-a-seat-vinyl-plush-blind-box') || previewProducts[0];
+  let activeProductId = defaultFeaturedBaseProduct.id;
+  let featuredProduct = toFeaturedProduct(defaultFeaturedBaseProduct);
+  let selectedVariantId = featuredProduct.variants[0].id;
+  let selectedMediaId = featuredProduct.media[0].id;
+  let previewCart = null;
+  let feedbackTimer = null;
+
+  const cartThresholds = {
+    freeShipping: Number(previewStorefrontConfig.cart?.freeShippingThreshold || 7500) / 100,
+    freeGift: Number(previewStorefrontConfig.cart?.freeGiftThreshold || 9000) / 100
+  };
+
+  function formatMoney(value) {
+    return `$${value.toFixed(2)}`;
+  }
+
+  function formatCents(value) {
+    return formatMoney((Number(value) || 0) / 100);
+  }
+
+  function createProductArt(title, [start, end], subtitle = '') {
+    const label = encodeURIComponent(title.toUpperCase());
+    const sub = encodeURIComponent(subtitle.toUpperCase());
+    return `data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 640 640'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0' y1='0' x2='1' y2='1'%3E%3Cstop stop-color='${encodeURIComponent(start)}'/%3E%3Cstop offset='1' stop-color='${encodeURIComponent(end)}'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect width='640' height='640' rx='40' fill='url(%23g)'/%3E%3Ccircle cx='194' cy='190' r='92' fill='%23ffffff' fill-opacity='.52'/%3E%3Ccircle cx='462' cy='430' r='126' fill='%23ffffff' fill-opacity='.28'/%3E%3Crect x='196' y='176' width='248' height='280' rx='110' fill='%23ffffff' fill-opacity='.92'/%3E%3Crect x='162' y='424' width='316' height='72' rx='36' fill='%231f2544' fill-opacity='.85'/%3E%3Ctext x='320' y='548' text-anchor='middle' font-family='Arial, sans-serif' font-size='30' font-weight='700' fill='%231f2544'%3E${label}%3C/text%3E%3Ctext x='320' y='585' text-anchor='middle' font-family='Arial, sans-serif' font-size='18' font-weight='700' fill='%236b7087'%3E${sub}%3C/text%3E%3C/svg%3E`;
+  }
+
+  function getProductImage(product, fallbackSubtitle = '') {
+    if (product?.featured_image) return product.featured_image;
+    return createProductArt(product?.title || 'Toybeta Preview', product?.bg || ['#ffd8e2', '#efe7ff'], fallbackSubtitle);
+  }
+
+  function getProduct(productId) {
+    return previewProducts.find((product) => String(product.id) === String(productId) || product.handle === productId);
+  }
+
+  function getSelectedVariant() {
+    return featuredProduct.variants.find((variant) => variant.id === selectedVariantId) || featuredProduct.variants[0];
+  }
+
+  function setActiveProduct(productId) {
     const product = getProduct(productId);
-    if (product) addToCart(productId, 1, product.kicker, { unitPrice: product.price, image: getProductImage(product, product.kicker) });
-    document.querySelector('[data-cart-toggle]')?.click();
-    return;
-  }
-
-  const variantButton = event.target.closest('[data-variant-id]');
-  if (variantButton) {
-    selectedVariantId = variantButton.dataset.variantId;
+    if (!product || product.id === 'collector-sleeve') return;
+    activeProductId = product.id;
+    featuredProduct = toFeaturedProduct(product);
+    selectedVariantId = featuredProduct.variants[0]?.id;
+    selectedMediaId = featuredProduct.media[0]?.id;
+    renderPreviewProducts();
+    syncSecondaryGrid();
     renderProductExperience();
-    return;
   }
 
-  const mediaButton = event.target.closest('[data-media-id]');
-  if (mediaButton) {
-    selectedMediaId = mediaButton.dataset.mediaId;
-    renderProductExperience();
-    return;
+  function getSelectedMedia() {
+    return featuredProduct.media.find((media) => media.id === selectedMediaId) || featuredProduct.media[0];
   }
 
-  const qtyButton = event.target.closest('[data-cart-qty]');
-  if (qtyButton) {
-    updateCartItem(qtyButton.dataset.cartKey, qtyButton.dataset.cartQty === 'increase' ? 1 : -1);
-    return;
-  }
-
-  const removeButton = event.target.closest('[data-cart-remove]');
-  if (removeButton) {
-    removeCartItem(removeButton.dataset.cartRemove);
-    return;
-  }
-
-  const upsellButton = event.target.closest('[data-cart-add="upsell"]');
-  if (upsellButton) {
-    addToCart('collector-sleeve', 1, 'Archive-safe protector', { unitPrice: 1200, image: getProductImage(getProduct('collector-sleeve'), 'Add-on') });
-    return;
-  }
-
-  const previewAddOnButton = event.target.closest('[data-preview-addon]');
-  if (previewAddOnButton) {
-    const addOnId = previewAddOnButton.dataset.previewAddon;
-    const addOn = previewAddOns.find((item) => item.id === addOnId);
-    const product = getProduct(addOnId);
-    if (addOn) {
-      addToCart(addOnId, 1, 'Product-page add-on', {
-        unitPrice: addOn.price,
-        image: getProductImage(product || { title: addOn.title, bg: ['#fff0d6', '#ffe3ef'] }, 'Add-on')
-      });
-      document.querySelector('[data-cart-toggle]')?.click();
+  function setFeedback(message = '', tone = 'success') {
+    if (!feedbackNode) return;
+    if (feedbackTimer) clearTimeout(feedbackTimer);
+    feedbackNode.textContent = message;
+    feedbackNode.classList.remove('is-success', 'is-error');
+    if (message) feedbackNode.classList.add(tone === 'error' ? 'is-error' : 'is-success');
+    if (message) {
+      feedbackTimer = window.setTimeout(() => {
+        feedbackNode.textContent = '';
+        feedbackNode.classList.remove('is-success', 'is-error');
+      }, 2400);
     }
-    return;
   }
-});
 
-document.addEventListener('change', (event) => {
-  if (event.target.id === 'variant-demo') {
-    selectedVariantId = event.target.value;
-    renderProductExperience();
-  }
-});
-
-const previewForm = document.getElementById('preview-product-form');
-if (previewForm) {
-  previewForm.addEventListener('submit', (event) => {
-    event.preventDefault();
-    const qty = Math.max(1, Number(previewForm.querySelector('[data-qty-input]')?.value || 1));
-    const variant = getSelectedVariant();
-    if (!variant.available) return;
-    addToCart(featuredBaseProduct.id, qty, variant.title, { unitPrice: variant.price, image: getSelectedMedia().src });
+  function openPreviewCart() {
+    const cartDrawer = document.querySelector('[data-cart-drawer]');
+    if (cartDrawer) {
+      cartDrawer.classList.add('is-open');
+      cartDrawer.setAttribute('aria-hidden', 'false');
+      document.body.classList.add('body-lock');
+      return;
+    }
     document.querySelector('[data-cart-toggle]')?.click();
+  }
+
+  function renderPreviewProducts() {
+    const grid = document.getElementById('preview-product-grid');
+    if (!grid) return;
+
+    grid.innerHTML = previewProducts
+      .filter((product) => product.id !== 'collector-sleeve')
+      .map((product) => `
+        <article class="card ${String(product.id) === String(activeProductId) ? 'is-selected' : ''}">
+          <a class="card-link" href="#product-preview" aria-label="${product.title}" data-preview-view="${product.id}">
+            <div class="card-media">
+              <img src="${getProductImage(product, product.kicker)}" alt="${product.title}">
+            </div>
+            <div class="card-body">
+              <div class="card-meta">
+                <div class="badge">${product.badge}</div>
+                <div class="card-kicker">${product.kicker}</div>
+              </div>
+              <h3>${product.title}</h3>
+              <div class="text-muted">${product.vendor}</div>
+              <div class="card-footer">
+                <div>
+                  <span class="price">${formatCents(product.price)}</span>
+                  ${product.compare_at_price ? `<span class="compare-at">${formatCents(product.compare_at_price)}</span>` : ''}
+                </div>
+                <span class="card-cta">Quick look →</span>
+              </div>
+              <div class="card-availability">${product.status}</div>
+            </div>
+          </a>
+          <div class="card-actions">
+            <button class="btn btn-secondary" type="button" data-preview-view="${product.id}">Preview details</button>
+            <button class="btn btn-primary" type="button" data-preview-add="${product.id}">Add to cart</button>
+          </div>
+        </article>
+      `).join('');
+  }
+
+  function syncSecondaryGrid() {
+    const secondaryGrid = document.getElementById('preview-product-grid-secondary');
+    const primaryGrid = document.getElementById('preview-product-grid');
+    if (secondaryGrid && primaryGrid) secondaryGrid.innerHTML = primaryGrid.innerHTML;
+  }
+
+  function renderAddOnPreview() {
+    const addOnStack = document.getElementById('preview-addon-stack');
+    if (!addOnStack) return;
+
+    addOnStack.innerHTML = previewAddOns.map((item) => {
+      const product = getProduct(item.id) || { title: item.title, bg: ['#fff0d6', '#ffe3ef'] };
+      return `
+        <article class="drawer-item">
+          <div class="drawer-thumb"><img src="${getProductImage(product, 'Add-on')}" alt="${item.title}"></div>
+          <div>
+            <div class="drawer-item-row"><strong>${item.title}</strong><span>${formatCents(item.price)}</span></div>
+            <div class="text-muted">${item.copy}</div>
+            <div class="quick-add-copy">${item.sourceNote}</div>
+            <button class="btn btn-secondary" type="button" data-preview-addon="${item.id}">${item.cta}</button>
+          </div>
+        </article>
+      `;
+    }).join('');
+  }
+
+  function renderProductExperience() {
+    const select = document.getElementById('variant-demo');
+    const chipRow = document.getElementById('variant-chip-row');
+    const thumbs = document.getElementById('product-thumbs');
+    const mainImage = document.getElementById('product-main-image');
+    const floatingNote = document.getElementById('gallery-floating-note');
+    const stockChip = document.getElementById('variant-stock-chip');
+    const priceChip = document.getElementById('variant-price-chip');
+    const bundleChip = document.getElementById('variant-bundle-chip');
+    const submit = document.getElementById('product-submit-button');
+    const productKicker = document.getElementById('product-kicker');
+    const productTitle = document.getElementById('product-title');
+    const productBadge = document.getElementById('product-badge');
+    const productPrice = document.getElementById('product-price');
+    const productCompareAt = document.getElementById('product-compare-at');
+    const productStatusRow = document.getElementById('product-status-row');
+    const productDescription = document.getElementById('product-description');
+    if (!select || !chipRow || !thumbs || !mainImage) return;
+
+    select.innerHTML = featuredProduct.variants.map((variant) => `<option value="${variant.id}">${variant.title}</option>`).join('');
+    select.value = selectedVariantId;
+
+    chipRow.innerHTML = featuredProduct.variants.map((variant) => `
+      <button class="variant-chip ${variant.id === selectedVariantId ? 'is-active' : ''}" type="button" data-variant-id="${variant.id}">${variant.title}</button>
+    `).join('');
+
+    thumbs.innerHTML = featuredProduct.media.map((media) => `
+      <button class="product-thumb-button ${media.id === selectedMediaId ? 'is-active' : ''}" type="button" data-media-id="${media.id}" aria-label="${media.label}">
+        <img src="${media.src}" alt="${media.label}">
+      </button>
+    `).join('');
+
+    const variant = getSelectedVariant();
+    const media = getSelectedMedia();
+    mainImage.src = media.src;
+    mainImage.alt = `${featuredProduct.title} ${media.label}`;
+    floatingNote.textContent = media.label;
+    stockChip.textContent = variant.stock;
+    priceChip.textContent = formatCents(variant.price);
+    bundleChip.textContent = variant.bundle;
+    if (productKicker) productKicker.textContent = featuredProduct.kicker || featuredProduct.vendor;
+    if (productTitle) productTitle.textContent = featuredProduct.title;
+    if (productBadge) productBadge.textContent = featuredProduct.badge || featuredProduct.status;
+    if (productPrice) productPrice.textContent = formatCents(variant.price);
+    if (productCompareAt) {
+      if (featuredProduct.compareAtPrice) {
+        productCompareAt.textContent = formatCents(featuredProduct.compareAtPrice);
+        productCompareAt.hidden = false;
+      } else {
+        productCompareAt.textContent = '';
+        productCompareAt.hidden = true;
+      }
+    }
+    if (productStatusRow) {
+      productStatusRow.innerHTML = featuredProduct.highlights.map((item) => `<span class="hero-chip">${item}</span>`).join('');
+    }
+    if (productDescription) productDescription.textContent = featuredProduct.description;
+    if (submit) submit.textContent = variant.available ? `Add ${variant.title} to cart` : `${variant.title} sold out`;
+    if (submit) submit.disabled = !variant.available;
+  }
+
+  function getCartSubtotal(cart) {
+    return (cart?.total_price || 0) / 100;
+  }
+
+  function renderCart(cart) {
+    previewCart = cart;
+    const itemsWrap = document.querySelector('[data-cart-drawer-items]') || document.getElementById('cart-drawer-items');
+    const miniPreview = document.getElementById('mini-cart-preview');
+    const total = document.querySelector('[data-cart-total]') || document.getElementById('cart-total');
+    const browseCount = document.getElementById('cart-browse-count');
+    const drawerCount = document.querySelector('[data-cart-count]');
+    const progress = document.querySelector('[data-cart-progress-copy]') || document.getElementById('cart-progress-copy');
+    const progressLabel = document.querySelector('[data-cart-progress-label]') || document.getElementById('cart-progress-label');
+    const progressFill = document.querySelector('[data-cart-progress-fill]') || document.getElementById('cart-progress-fill');
+    const heading = document.querySelector('[data-cart-heading]') || document.getElementById('cart-drawer-heading');
+    const thresholdCopy = document.querySelector('[data-cart-threshold-copy]');
+    if (!itemsWrap || !miniPreview || !total || !browseCount) return;
+
+    if (thresholdCopy) {
+      thresholdCopy.textContent = `Free shipping at ${formatMoney(cartThresholds.freeShipping)}, free gift at ${formatMoney(cartThresholds.freeGift)}`;
+    }
+
+    const subtotal = getCartSubtotal(cart);
+    const countValue = cart.item_count || 0;
+    const freeShippingGap = Math.max(0, cartThresholds.freeShipping - subtotal);
+    const freeGiftGap = Math.max(0, cartThresholds.freeGift - subtotal);
+    const progressPercent = Math.min(100, (subtotal / cartThresholds.freeGift) * 100);
+
+    browseCount.textContent = `${countValue} item${countValue === 1 ? '' : 's'}`;
+    if (drawerCount) drawerCount.textContent = `${countValue} item${countValue === 1 ? '' : 's'}`;
+    total.textContent = formatMoney(subtotal);
+    if (progressLabel) {
+      progressLabel.textContent = freeGiftGap > 0
+        ? `${Math.round(progressPercent)}% to your free gift`
+        : 'Free gift unlocked';
+    }
+    if (progressFill) progressFill.style.width = `${progressPercent}%`;
+    if (progress) {
+      if (freeShippingGap > 0) {
+        progress.textContent = `Add ${formatMoney(freeShippingGap)} more for free shipping, then ${formatMoney(freeGiftGap)} more unlocks the collector gift.`;
+      } else if (freeGiftGap > 0) {
+        progress.textContent = `Free shipping unlocked. Add ${formatMoney(freeGiftGap)} more to score the collector gift.`;
+      } else {
+        progress.textContent = 'Free shipping and the collector gift are both unlocked. This is the moment to push checkout.';
+      }
+    }
+    if (heading) heading.textContent = countValue ? `You have ${countValue} collector pick${countValue === 1 ? '' : 's'} ready` : 'Your drop is almost locked in';
+
+    const markup = (cart.items || []).map((item) => {
+      const product = getProduct(item.productId) || { title: item.product_title || featuredProduct.title, price: (item.unitPrice || getSelectedVariant().price), bg: item.bg || ['#ffd7df', '#d6d8ff'], cartNote: item.variantTitle };
+      const lineTotal = (item.final_line_price || ((item.unitPrice || product.price) * item.quantity)) / 100;
+      const image = item.image || getProductImage(product, item.variantTitle || product.cartNote || 'Collector pick');
+      return `
+        <article class="drawer-item">
+          <div class="drawer-thumb"><img src="${image}" alt="${product.title}"></div>
+          <div>
+            <div class="drawer-item-row"><strong>${product.title}</strong><span>${formatMoney(lineTotal)}</span></div>
+            <div class="text-muted">${item.variantTitle || product.cartNote || 'Collector pick'}</div>
+            <div class="drawer-item-meta">
+              <div class="qty-stepper">
+                <button type="button" data-cart-qty="decrease" data-cart-key="${item.key}">−</button>
+                <span>${item.quantity}</span>
+                <button type="button" data-cart-qty="increase" data-cart-key="${item.key}">+</button>
+              </div>
+              <button class="btn btn-secondary" type="button" data-cart-remove="${item.key}">Remove</button>
+            </div>
+          </div>
+        </article>
+      `;
+    }).join('');
+
+    const emptyMarkup = '<div class="drawer-note text-muted"><p>Your cart is empty in preview mode. Add a hero SKU or an upsell to show the drawer flow.</p></div>';
+    itemsWrap.innerHTML = markup || emptyMarkup;
+    miniPreview.innerHTML = markup ? (cart.items || []).slice(0, 1).map((item) => {
+      const product = getProduct(item.productId) || { title: item.product_title || featuredProduct.title, price: item.unitPrice || getSelectedVariant().price, bg: ['#ffd7df', '#d6d8ff'], cartNote: item.variantTitle };
+      const image = item.image || getProductImage(product, item.variantTitle || '');
+      return `<div class="drawer-item"><div class="drawer-thumb"><img src="${image}" alt="${product.title}"></div><div><div class="drawer-item-row"><strong>${product.title}</strong><span>${formatMoney((item.final_line_price || ((item.unitPrice || product.price) * item.quantity)) / 100)}</span></div><div class="text-muted">Qty ${item.quantity} • ${item.variantTitle || product.cartNote || 'Collector pick'}</div></div></div>`;
+    }).join('') : '<div class="text-muted"><p>No items yet. This panel updates with the drawer state.</p></div>';
+  }
+
+  function addToCart(productId, quantity = 1, variantTitle = '', overrides = {}) {
+    const product = getProduct(productId);
+    const image = overrides.image || product?.featured_image || createProductArt(overrides.title || product?.title || featuredProduct.title, overrides.bg || product?.bg || ['#ffd7df', '#d6d8ff'], variantTitle || overrides.subtitle || '');
+    return previewCartApi.addItem({
+      id: productId,
+      productId,
+      product_title: overrides.title || product?.title || featuredProduct.title,
+      title: overrides.title || product?.title || featuredProduct.title,
+      quantity,
+      variantTitle,
+      unitPrice: Math.round(Number(overrides.unitPrice ?? product?.price ?? 0)),
+      image
+    });
+  }
+
+  function updateCartItem(cartKey, delta) {
+    const existing = (previewCart?.items || []).find((item) => item.key === cartKey);
+    if (!existing) return Promise.resolve(previewCart);
+    return previewCartApi.updateItem(cartKey, existing.quantity + delta);
+  }
+
+  function removeCartItem(cartKey) {
+    return previewCartApi.removeItem(cartKey);
+  }
+
+  async function addPreviewItem({ productId, quantity = 1, variantTitle = '', overrides = {}, successMessage, button }) {
+    const originalLabel = button?.textContent;
+    try {
+      if (button) {
+        button.disabled = true;
+        button.textContent = 'Adding…';
+      }
+      await addToCart(productId, quantity, variantTitle, overrides);
+      openPreviewCart();
+      setFeedback(successMessage || 'Added to preview cart.');
+    } catch (error) {
+      console.warn('Preview add to cart failed', error);
+      setFeedback('Add to cart failed in preview mode.', 'error');
+    } finally {
+      if (button) {
+        button.disabled = false;
+        button.textContent = originalLabel || 'Add to cart';
+      }
+    }
+  }
+
+  document.addEventListener('click', async (event) => {
+    const viewButton = event.target.closest('[data-preview-view]');
+    if (viewButton) {
+      setActiveProduct(viewButton.dataset.previewView);
+      document.getElementById('product-preview')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      return;
+    }
+
+    const addButton = event.target.closest('[data-preview-add]');
+    if (addButton) {
+      const productId = addButton.dataset.previewAdd;
+      const product = getProduct(productId);
+      if (product) {
+        await addPreviewItem({
+          productId,
+          variantTitle: product.kicker,
+          overrides: { unitPrice: product.price, image: getProductImage(product, product.kicker) },
+          successMessage: `${product.title} added to the preview cart.`,
+          button: addButton
+        });
+      }
+      return;
+    }
+
+    const variantButton = event.target.closest('[data-variant-id]');
+    if (variantButton) {
+      selectedVariantId = variantButton.dataset.variantId;
+      renderProductExperience();
+      return;
+    }
+
+    const mediaButton = event.target.closest('[data-media-id]');
+    if (mediaButton) {
+      selectedMediaId = mediaButton.dataset.mediaId;
+      renderProductExperience();
+      return;
+    }
+
+    const qtyButton = event.target.closest('[data-cart-qty]');
+    if (qtyButton) {
+      await updateCartItem(qtyButton.dataset.cartKey, qtyButton.dataset.cartQty === 'increase' ? 1 : -1);
+      return;
+    }
+
+    const removeButton = event.target.closest('[data-cart-remove]');
+    if (removeButton) {
+      await removeCartItem(removeButton.dataset.cartRemove);
+      setFeedback('Item removed from the preview cart.');
+      return;
+    }
+
+    const upsellButton = event.target.closest('[data-cart-add="upsell"]');
+    if (upsellButton) {
+      await addPreviewItem({
+        productId: 'collector-sleeve',
+        variantTitle: 'Archive-safe protector',
+        overrides: { unitPrice: 1200, image: getProductImage(getProduct('collector-sleeve'), 'Add-on') },
+        successMessage: 'Collector Sleeve added to the preview cart.',
+        button: upsellButton
+      });
+      return;
+    }
+
+    const previewAddOnButton = event.target.closest('[data-preview-addon]');
+    if (previewAddOnButton) {
+      const addOnId = previewAddOnButton.dataset.previewAddon;
+      const addOn = previewAddOns.find((item) => item.id === addOnId);
+      const product = getProduct(addOnId);
+      if (addOn) {
+        await addPreviewItem({
+          productId: addOnId,
+          variantTitle: 'Product-page add-on',
+          overrides: {
+            unitPrice: addOn.price,
+            image: getProductImage(product || { title: addOn.title, bg: ['#fff0d6', '#ffe3ef'] }, 'Add-on')
+          },
+          successMessage: `${addOn.title} added to the preview cart.`,
+          button: previewAddOnButton
+        });
+      }
+    }
   });
-}
 
-renderPreviewProducts();
-syncSecondaryGrid();
-renderAddOnPreview();
-renderProductExperience();
+  document.addEventListener('change', (event) => {
+    if (event.target.id === 'variant-demo') {
+      selectedVariantId = event.target.value;
+      renderProductExperience();
+    }
+  });
 
-cartApi.subscribe(renderCart);
+  const previewForm = document.getElementById('preview-product-form');
+  if (previewForm) {
+    previewForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const qty = Math.max(1, Number(previewForm.querySelector('[data-qty-input]')?.value || 1));
+      const variant = getSelectedVariant();
+      const submitButton = document.getElementById('product-submit-button');
+      if (!variant.available) return;
+      await addPreviewItem({
+        productId: activeProductId,
+        quantity: qty,
+        variantTitle: variant.title,
+        overrides: { unitPrice: variant.price, image: getSelectedMedia().src },
+        successMessage: `${featuredProduct.title} (${variant.title}) added to the preview cart.`,
+        button: submitButton
+      });
+    });
+  }
 
-if (storefront.config.mode === 'local_preview' && !window.TOYBETA_STOREFRONT_CONFIG?.previewCartItems?.length) {
-  addToCart(7902382751894, 1, 'Best seller', { unitPrice: 3999, image: getProductImage(getProduct(7902382751894), 'Blind box') });
-}
+  renderPreviewProducts();
+  syncSecondaryGrid();
+  renderAddOnPreview();
+  renderProductExperience();
+
+  if (previewCartApi?.subscribe) {
+    previewCartApi.subscribe(renderCart);
+  }
+
+  if (previewStorefront.config.mode === 'local_preview') {
+    previewCartApi.getCart().then((cart) => {
+      if (!cart?.item_count && !window.TOYBETA_STOREFRONT_CONFIG?.previewCartItems?.length) {
+        addToCart(7902382751894, 1, 'Best seller', { unitPrice: 3999, image: getProductImage(getProduct(7902382751894), 'Blind box') });
+      }
+    });
+  }
+})();

--- a/preview.html
+++ b/preview.html
@@ -35,11 +35,13 @@
           <a href="#collection-preview">Collection</a>
           <a href="#product-preview">Product</a>
           <a href="#vip">VIP</a>
+          <a href="preview-checkout.html">Demo checkout</a>
         </nav>
         <div class="header-actions">
           <a class="btn btn-secondary" href="#collection-preview">Shop layout</a>
           <button class="btn btn-primary" type="button" data-cart-toggle>Cart preview</button>
         </div>
+        <p class="preview-cart-feedback" id="preview-cart-feedback" aria-live="polite"></p>
       </div>
     </header>
 
@@ -345,21 +347,21 @@
             <div class="product-panel">
               <div class="product-heading">
                 <div>
-                  <div class="eyebrow">Future Shelf</div>
-                  <h1>Neon Robo Secret Edition</h1>
+                  <div class="eyebrow" id="product-kicker">Future Shelf</div>
+                  <h1 id="product-title">Neon Robo Secret Edition</h1>
                 </div>
-                <div class="badge badge-outline">Preorder</div>
+                <div class="badge badge-outline" id="product-badge">Preorder</div>
               </div>
               <div>
-                <span class="price">$39.00</span>
-                <span class="compare-at">$45.00</span>
+                <span class="price" id="product-price">$39.00</span>
+                <span class="compare-at" id="product-compare-at">$45.00</span>
               </div>
-              <div class="product-status-row">
+              <div class="product-status-row" id="product-status-row">
                 <span class="hero-chip">Collector-grade packaging</span>
                 <span class="hero-chip">Tracked shipping</span>
                 <span class="hero-chip">Gift note ready</span>
               </div>
-              <div class="text-muted product-description"><p>A polished product template needs both story and reassurance. This layout gives the price, status, core benefits, and next-step cart behavior a tighter hierarchy.</p></div>
+              <div class="text-muted product-description"><p id="product-description">A polished product template needs both story and reassurance. This layout gives the price, status, core benefits, and next-step cart behavior a tighter hierarchy.</p></div>
               <form class="product-form" id="preview-product-form">
                 <div class="option-group">
                   <label for="variant-demo">Edition</label>
@@ -384,7 +386,8 @@
                   </div>
                   <button class="btn btn-secondary" type="button" data-cart-toggle>Open preview</button>
                 </div>
-                <div class="text-muted"><p>This reinforces the next step without forcing shoppers off the product page. Keep it as a demo placeholder or wire it into Ajax cart later.</p></div>
+                <div class="text-muted"><p>This reinforces the next step without forcing shoppers off the product page. In local preview mode, it now hands off to a separate demo checkout flow instead of a real Shopify checkout.</p></div>
+                <a class="btn btn-primary" href="preview-checkout.html">Continue to demo checkout</a>
               </div>
               <div class="mini-cart-panel">
                 <div class="mini-cart-header">
@@ -467,20 +470,21 @@
         <div class="drawer-panel drawer-header">
           <div>
             <div class="eyebrow">Ajax cart preview</div>
-            <h3 id="cart-drawer-heading">Your drop is almost locked in</h3>
+            <h3 id="cart-drawer-heading" data-cart-heading>Your drop is almost locked in</h3>
           </div>
+          <div class="badge badge-outline" data-cart-count>0 items</div>
           <button class="drawer-close" type="button" aria-label="Close cart drawer" data-cart-close>×</button>
         </div>
         <div class="drawer-scroll">
           <div class="drawer-upsell-banner">
             <div class="drawer-progress-row">
               <strong data-cart-threshold-copy>Free shipping at $75, free gift at $90</strong>
-              <span class="badge badge-outline" id="cart-progress-label">0% to your free gift</span>
+              <span class="badge badge-outline" id="cart-progress-label" data-cart-progress-label>0% to your free gift</span>
             </div>
-            <div class="progress-track" aria-hidden="true"><span class="progress-fill" id="cart-progress-fill"></span></div>
-            <span class="text-muted" id="cart-progress-copy">Add one more blind box to cross the threshold.</span>
+            <div class="progress-track" aria-hidden="true"><span class="progress-fill" id="cart-progress-fill" data-cart-progress-fill></span></div>
+            <span class="text-muted" id="cart-progress-copy" data-cart-progress-copy>Add one more blind box to cross the threshold.</span>
           </div>
-          <div class="drawer-items" id="cart-drawer-items"></div>
+          <div class="drawer-items" id="cart-drawer-items" data-cart-drawer-items></div>
           <div class="drawer-note text-muted">
             <p>Great place to call out preorder timing, free shipping threshold, or a bundle nudge before checkout.</p>
           </div>
@@ -489,13 +493,13 @@
           <div class="drawer-summary">
             <div>
               <div class="eyebrow">Estimated total</div>
-              <strong id="cart-total">$0.00</strong>
+              <strong id="cart-total" data-cart-total>$0.00</strong>
             </div>
             <a class="btn btn-secondary" href="#product-preview">View cart</a>
           </div>
           <div class="drawer-actions-secondary">
             <button class="btn btn-secondary" type="button" data-cart-add="upsell">Add collector sleeve $12</button>
-            <button class="btn btn-primary" type="button" data-cart-close>Checkout feel</button>
+            <a class="btn btn-primary" href="preview-checkout.html">Checkout demo →</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- make product-card preview actions switch the active localhost PDP product in-page
- render PDP title, pricing, gallery, badges, description, and variant state from the selected mock product
- ensure add-to-cart on the PDP uses the active selected product and variant

## Testing
- node -c assets/preview.js
- python3 hook check for preview.html PDP bindings
