### PR TITLE
feat: optimize mobile navigation and spacing

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -131,6 +131,93 @@ p { line-height: 1.65; }
 }
 .nav a:hover::after { transform: scaleX(1); }
 .header-actions { display: flex; align-items: center; gap: .75rem; }
+.header-actions-mobile,
+.mobile-menu {
+  display: none;
+}
+.menu-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: .28rem;
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  border: 1px solid var(--line);
+  background: rgba(255,255,255,.92);
+  box-shadow: var(--shadow-soft);
+  cursor: pointer;
+}
+.menu-toggle span {
+  display: block;
+  width: 18px;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--ink);
+  transition: transform .2s ease, opacity .2s ease;
+}
+.menu-toggle.is-active span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+.menu-toggle.is-active span:nth-child(2) { opacity: 0; }
+.menu-toggle.is-active span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+.btn-compact {
+  min-height: 48px;
+  padding-inline: 1rem;
+}
+.mobile-menu {
+  position: fixed;
+  inset: 0;
+  z-index: 55;
+}
+.mobile-menu[hidden] {
+  display: none !important;
+}
+.mobile-menu__backdrop {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background: rgba(20, 23, 45, 0.34);
+}
+.mobile-menu__panel {
+  position: absolute;
+  top: .75rem;
+  left: .75rem;
+  right: .75rem;
+  padding: 1rem;
+  border-radius: 28px;
+  background: rgba(255,255,255,.98);
+  border: 1px solid var(--line);
+  box-shadow: 0 24px 60px rgba(31, 37, 68, 0.18);
+  display: grid;
+  gap: 1rem;
+}
+.mobile-menu__header,
+.mobile-menu__footer,
+.mobile-menu__nav a {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .75rem;
+}
+.mobile-menu__nav {
+  display: grid;
+  gap: .65rem;
+}
+.mobile-menu__nav a {
+  min-height: 52px;
+  padding: 1rem;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(255,248,244,.96), rgba(247,247,255,.96));
+  border: 1px solid var(--line);
+  font-weight: 700;
+}
+.mobile-menu__footer {
+  display: grid;
+  grid-template-columns: 1fr;
+}
+.mobile-menu__footer .btn {
+  width: 100%;
+}
 .announcement-bar {
   background: linear-gradient(90deg, var(--accent-2), #8979ff);
   color: #fff;
@@ -1001,11 +1088,41 @@ p { line-height: 1.65; }
     display: grid;
     grid-template-columns: 1fr;
   }
-  .nav {
-    overflow: auto;
-    white-space: nowrap;
-    gap: .6rem;
-    padding-bottom: .2rem;
+  .site-header {
+    backdrop-filter: blur(20px);
+  }
+  .header-shell {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: .85rem;
+    padding: .85rem 0;
+  }
+  .nav-desktop,
+  .header-actions--desktop {
+    display: none;
+  }
+  .header-actions-mobile,
+  .mobile-menu {
+    display: block;
+  }
+  .header-actions-mobile {
+    display: flex;
+    align-items: center;
+    justify-content: end;
+    gap: .65rem;
+  }
+  .brand {
+    min-width: 0;
+    font-size: 1.2rem;
+  }
+  .brand img {
+    max-height: 34px;
+  }
+  .btn {
+    min-height: 48px;
+  }
+  .drawer-item {
+    grid-template-columns: 72px 1fr;
   }
   .demo-banner,
   .checkout-option,
@@ -1017,15 +1134,19 @@ p { line-height: 1.65; }
   .hero { padding-top: 2.25rem; }
   .hero-card { padding: 1.25rem; }
   .hero-media { min-height: 280px; }
-  .card-grid,
-  .collection-banner-stats,
-  .product-thumbs { grid-template-columns: 1fr; }
+  .card-grid { grid-template-columns: 1fr; }
+  .collection-banner-stats { grid-template-columns: 1fr; }
+  .product-thumbs { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .drawer-actions-secondary,
   .variant-chip-row,
   .mini-launch-strip,
   .launch-timeline { display: grid; grid-template-columns: 1fr; }
   .section { padding: 3rem 0; }
-  .section-heading { align-items: start; }
+  .section-heading {
+    align-items: start;
+    gap: .75rem;
+    margin-bottom: 1.1rem;
+  }
   .qty-row { align-items: stretch; flex-direction: column; }
   .mini-cart-panel,
   .filter-panel,

--- a/assets/theme.js
+++ b/assets/theme.js
@@ -18,6 +18,8 @@ const drawerHeading = document.querySelector('[data-cart-heading]');
 const drawerProgressCopy = document.querySelector('[data-cart-progress-copy]');
 const drawerProgressLabel = document.querySelector('[data-cart-progress-label]');
 const drawerProgressFill = document.querySelector('[data-cart-progress-fill]');
+const mobileMenu = document.querySelector('[data-mobile-menu]');
+const menuToggle = document.querySelector('[data-menu-toggle]');
 
 const storefrontConfig = window.TOYBETA_STOREFRONT_CONFIG || {};
 const cartThresholds = {
@@ -46,7 +48,16 @@ function setCartDrawerState(isOpen) {
   if (!cartDrawer) return;
   cartDrawer.classList.toggle('is-open', isOpen);
   cartDrawer.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
-  document.body.classList.toggle('body-lock', isOpen);
+  document.body.classList.toggle('body-lock', isOpen || mobileMenu?.hidden === false);
+}
+
+function setMobileMenuState(isOpen) {
+  if (!mobileMenu || !menuToggle) return;
+  mobileMenu.hidden = !isOpen;
+  menuToggle.classList.toggle('is-active', isOpen);
+  menuToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+  menuToggle.setAttribute('aria-label', isOpen ? 'Close menu' : 'Open menu');
+  document.body.classList.toggle('body-lock', isOpen || cartDrawer?.classList.contains('is-open'));
 }
 
 function formatMoney(cents, currency = 'USD') {
@@ -159,22 +170,32 @@ async function submitCartRequest({ form, openDrawer = true }) {
   }
 }
 
-if (cartDrawer) {
-  document.addEventListener('click', (event) => {
-    if (event.target.closest('[data-cart-toggle]')) {
-      refreshCartDrawer(true);
-      return;
-    }
+document.addEventListener('click', (event) => {
+  if (event.target.closest('[data-menu-toggle]')) {
+    setMobileMenuState(mobileMenu?.hidden !== false);
+    return;
+  }
 
-    if (event.target.closest('[data-cart-close]')) {
-      setCartDrawerState(false);
-    }
-  });
+  if (event.target.closest('[data-menu-close]') || event.target.closest('[data-menu-link]')) {
+    setMobileMenuState(false);
+  }
 
-  document.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape') setCartDrawerState(false);
-  });
-}
+  if (event.target.closest('[data-cart-toggle]')) {
+    setMobileMenuState(false);
+    refreshCartDrawer(true);
+    return;
+  }
+
+  if (event.target.closest('[data-cart-close]')) {
+    setCartDrawerState(false);
+  }
+});
+
+document.addEventListener('keydown', (event) => {
+  if (event.key !== 'Escape') return;
+  setMobileMenuState(false);
+  setCartDrawerState(false);
+});
 
 document.addEventListener('submit', (event) => {
   const form = event.target.closest('[data-product-form]');

--- a/preview.html
+++ b/preview.html
@@ -28,7 +28,7 @@
     <header class="site-header">
       <div class="page-width header-shell">
         <a class="brand" href="#top">Toybeta MVP</a>
-        <nav class="nav" aria-label="Primary navigation">
+        <nav class="nav nav-desktop" aria-label="Primary navigation">
           <a href="#new-arrivals">New arrivals</a>
           <a href="#story">Story blocks</a>
           <a href="#campaigns">Campaigns</a>
@@ -37,11 +37,43 @@
           <a href="#vip">VIP</a>
           <a href="preview-checkout.html">Demo checkout</a>
         </nav>
-        <div class="header-actions">
+        <div class="header-actions header-actions--desktop">
           <a class="btn btn-secondary" href="#collection-preview">Shop layout</a>
           <button class="btn btn-primary" type="button" data-cart-toggle>Cart preview</button>
         </div>
+        <div class="header-actions-mobile">
+          <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="MobileMenu" aria-label="Open menu" data-menu-toggle>
+            <span></span>
+            <span></span>
+            <span></span>
+          </button>
+          <button class="btn btn-primary btn-compact" type="button" data-cart-toggle>Cart</button>
+        </div>
+      </div>
+      <div class="page-width">
         <p class="preview-cart-feedback" id="preview-cart-feedback" aria-live="polite"></p>
+      </div>
+      <div class="mobile-menu" id="MobileMenu" data-mobile-menu hidden>
+        <button class="mobile-menu__backdrop" type="button" tabindex="-1" aria-label="Close menu" data-menu-close></button>
+        <div class="mobile-menu__panel" role="dialog" aria-modal="true" aria-label="Preview menu">
+          <div class="mobile-menu__header">
+            <strong>Toybeta MVP</strong>
+            <button class="drawer-close" type="button" aria-label="Close menu" data-menu-close>×</button>
+          </div>
+          <nav class="mobile-menu__nav" aria-label="Mobile navigation">
+            <a href="#new-arrivals" data-menu-link><span>New arrivals</span><span aria-hidden="true">→</span></a>
+            <a href="#story" data-menu-link><span>Story blocks</span><span aria-hidden="true">→</span></a>
+            <a href="#campaigns" data-menu-link><span>Campaigns</span><span aria-hidden="true">→</span></a>
+            <a href="#collection-preview" data-menu-link><span>Collection</span><span aria-hidden="true">→</span></a>
+            <a href="#product-preview" data-menu-link><span>Product</span><span aria-hidden="true">→</span></a>
+            <a href="#vip" data-menu-link><span>VIP</span><span aria-hidden="true">→</span></a>
+            <a href="preview-checkout.html" data-menu-link><span>Demo checkout</span><span aria-hidden="true">→</span></a>
+          </nav>
+          <div class="mobile-menu__footer">
+            <a class="btn btn-secondary" href="#collection-preview" data-menu-link>Shop layout</a>
+            <button class="btn btn-primary" type="button" data-cart-toggle data-menu-close>Open cart</button>
+          </div>
+        </div>
       </div>
     </header>
 

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -1,3 +1,5 @@
+{% assign header_menu = section.settings.menu | default: linklists.main-menu %}
+
 <header class="site-header">
   <div class="page-width header-shell">
     <a class="brand" href="{{ routes.root_url }}">
@@ -8,18 +10,52 @@
       {% endif %}
     </a>
 
-    {% assign header_menu = section.settings.menu | default: linklists.main-menu %}
-    <nav class="nav" aria-label="Primary navigation">
+    <nav class="nav nav-desktop" aria-label="Primary navigation">
       {% for link in header_menu.links %}
         <a href="{{ link.url }}">{{ link.title }}</a>
       {% endfor %}
     </nav>
 
-    <div class="header-actions">
+    <div class="header-actions header-actions--desktop">
       <a class="btn btn-secondary" href="{{ routes.search_url | default: '/search' }}">Search</a>
       <button class="btn btn-primary" type="button" data-cart-toggle>
         Cart{% if cart.item_count > 0 %} ({{ cart.item_count }}){% endif %}
       </button>
+    </div>
+
+    <div class="header-actions-mobile">
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="MobileMenu" aria-label="Open menu" data-menu-toggle>
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+      <button class="btn btn-primary btn-compact" type="button" data-cart-toggle>
+        Cart{% if cart.item_count > 0 %} ({{ cart.item_count }}){% endif %}
+      </button>
+    </div>
+  </div>
+
+  <div class="mobile-menu" id="MobileMenu" data-mobile-menu hidden>
+    <button class="mobile-menu__backdrop" type="button" tabindex="-1" aria-label="Close menu" data-menu-close></button>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true" aria-label="Site menu">
+      <div class="mobile-menu__header">
+        <strong>{{ shop.name }}</strong>
+        <button class="drawer-close" type="button" aria-label="Close menu" data-menu-close>×</button>
+      </div>
+      <nav class="mobile-menu__nav" aria-label="Mobile navigation">
+        {% for link in header_menu.links %}
+          <a href="{{ link.url }}" data-menu-link>
+            <span>{{ link.title }}</span>
+            <span aria-hidden="true">→</span>
+          </a>
+        {% endfor %}
+      </nav>
+      <div class="mobile-menu__footer">
+        <a class="btn btn-secondary" href="{{ routes.search_url | default: '/search' }}">Search</a>
+        <button class="btn btn-primary" type="button" data-cart-toggle data-menu-close>
+          Open cart{% if cart.item_count > 0 %} ({{ cart.item_count }}){% endif %}
+        </button>
+      </div>
     </div>
   </div>
 </header>


### PR DESCRIPTION
## Summary\n- replace the cramped mobile top nav with a hamburger-triggered drawer while keeping desktop nav intact\n- improve mobile tap targets, spacing, and card/list readability in the shared theme styles\n- mirror the new header pattern in the local preview so the mobile demo matches the Shopify section behavior\n\n## Testing\n- node --check assets/theme.js\n- node --check assets/preview.js\n- git diff --check\n- curl -I http://127.0.0.1:8000/preview.html\n\n## Notes\n- attempted automated browser verification, but the host does not currently have the  CLI installed\n\nCloses #8